### PR TITLE
register gov submitProposal initial amount sufficient error

### DIFF
--- a/x/gov/keeper/msg_server.go
+++ b/x/gov/keeper/msg_server.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"fmt"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"strconv"
 
 	"github.com/armon/go-metrics"
@@ -34,8 +35,9 @@ func (k msgServer) SubmitProposal(goCtx context.Context, msg *types.MsgSubmitPro
 	defer telemetry.IncrCounter(1, types.ModuleName, "proposal")
 
 	if k.SupportEGFProposal(ctx) {
-		if msg.GetInitialDeposit().IsAllLT(k.Keeper.GetEGFDepositParams(ctx).InitialDeposit) {
-			return nil, fmt.Errorf("initial amount too low")
+		paramsInitialDeposit := k.Keeper.GetEGFDepositParams(ctx).InitialDeposit
+		if msg.GetInitialDeposit().IsAllLT(paramsInitialDeposit) {
+			return nil, sdkerrors.Wrapf(types.ErrInitialAmountTooLow, "%s is smaller than %s", msg.GetInitialDeposit().String(), paramsInitialDeposit.String())
 		}
 	}
 

--- a/x/gov/types/errors.go
+++ b/x/gov/types/errors.go
@@ -14,4 +14,5 @@ var (
 	ErrInvalidVote             = sdkerrors.Register(ModuleName, 7, "invalid vote option")
 	ErrInvalidGenesis          = sdkerrors.Register(ModuleName, 8, "invalid genesis state")
 	ErrNoProposalHandlerExists = sdkerrors.Register(ModuleName, 9, "no handler exists for proposal type")
+	ErrInitialAmountTooLow     = sdkerrors.Register(ModuleName, 10, "initial amount too low")
 )


### PR DESCRIPTION
submitProposal get error


simulate tx error:
`Error: rpc error: code = InvalidArgument desc = failed to execute message; message index: 0: initial amount too low: invalid request`


no simulate tx fail response:

codespace: `underfined`
code: 1
raw_log: `internal`
{"height":"134","txhash":"B012363DE44027358B3FAFB578BE7D608F77F9D2079E778E9B4202BF79938777","codespace":"undefined","code":1,"data":"","raw_log":"internal","logs":[],"info":"","gas_wanted":"200000","gas_used":"137526","tx":null,"timestamp":"","events":[]}


**fix after**
simulate tx error:
Error: rpc error: code = InvalidArgument desc = failed to execute message; message index: 0: 10000000000000FX is smaller than 1000000000000000000000FX: initial amount too low: invalid request


no simulate tx fail response:
codespace: `gov`
code: 10
raw_log: `failed to execute message; message index: 0: 10000000000000FX is smaller than 1000000000000000000000FX: initial amount too low`

{"height":"397","txhash":"79970B7F0BCBEBFCC94742F3C2E95065806CA69EB79C16DABAB15204E8AAD4D0","codespace":"gov","code":10,"data":"","raw_log":"failed to execute message; message index: 0: 10000000000000FX is smaller than 1000000000000000000000FX: initial amount too low","logs":[],"info":"","gas_wanted":"200000","gas_used":"137586","tx":null,"timestamp":"","events":[]}